### PR TITLE
Support the new redir 3.x command line interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ to see it in action.
 ## Features
 
 * Provides the same workflow as the Vagrant VirtualBox provider
-* Port forwarding via [`redir`](http://linux.die.net/man/1/redir)
+* Port forwarding via [`redir`](https://github.com/troglobit/redir)
 * Private networking via [`pipework`](https://github.com/jpetazzo/pipework)
 
 ## Requirements

--- a/lib/vagrant-lxc/action/forward_ports.rb
+++ b/lib/vagrant-lxc/action/forward_ports.rb
@@ -1,3 +1,5 @@
+require 'open3'
+
 module Vagrant
   module LXC
     module Action
@@ -78,8 +80,13 @@ module Vagrant
         end
 
         def redirect_port(host_ip, host_port, guest_ip, guest_port)
-          params = %W( --lport=#{host_port} --caddr=#{guest_ip} --cport=#{guest_port} )
-          params.unshift "--laddr=#{host_ip}" if host_ip
+          if redir_version >= 3
+            params = %W( :#{host_port} #{guest_ip}:#{guest_port} )
+            params[0] =  "#{host_ip}:#{host_port}" if host_ip
+          else
+            params = %W( --lport=#{host_port} --caddr=#{guest_ip} --cport=#{guest_port} )
+            params.unshift "--laddr=#{host_ip}" if host_ip
+          end
           params << '--syslog' if ENV['REDIR_LOG']
           if host_port < 1024
             redir_cmd = "sudo redir #{params.join(' ')} 2>/dev/null"
@@ -97,6 +104,11 @@ module Vagrant
           data_dir.join("redir_#{host_port}.pid").open('w') do |pid_file|
             pid_file.write(redir_pid)
           end
+        end
+
+        def redir_version
+          _, version, _ = Open3.capture3 "redir --version"
+          version.split('.')[0].to_i
         end
 
         def redir_installed?

--- a/spec/unit/action/forward_ports_spec.rb
+++ b/spec/unit/action/forward_ports_spec.rb
@@ -24,6 +24,7 @@ describe Vagrant::LXC::Action::ForwardPorts do
     machine.stub_chain(:config, :vm, :networks).and_return(networks)
     machine.stub(provider: provider, data_dir: data_dir)
 
+    subject.stub(redir_version: 3)
     subject.stub(exec: true)
     subject.stub(spawn: pid)
   end
@@ -34,7 +35,7 @@ describe Vagrant::LXC::Action::ForwardPorts do
     subject.stub(system: true)
     subject.call(env)
     expect(subject).to have_received(:spawn).with(
-      "redir --laddr=#{host_ip} --lport=#{host_port} --caddr=#{container_ip} --cport=#{guest_port} 2>/dev/null"
+      "redir #{host_ip}:#{host_port} #{container_ip}:#{guest_port} 2>/dev/null"
     )
   end
 
@@ -43,7 +44,7 @@ describe Vagrant::LXC::Action::ForwardPorts do
     subject.stub(system: true)
     subject.call(env)
     expect(subject).to have_received(:spawn).with(
-      "redir --laddr=127.0.0.1 --lport=#{host_port} --caddr=#{container_ip} --cport=#{guest_port} 2>/dev/null"
+      "redir 127.0.0.1:#{host_port} #{container_ip}:#{guest_port} 2>/dev/null"
     )
   end
 
@@ -52,7 +53,7 @@ describe Vagrant::LXC::Action::ForwardPorts do
     subject.stub(system: true)
     subject.call(env)
     expect(subject).to have_received(:spawn).with(
-      "redir --laddr=127.0.0.1 --lport=#{host_port} --caddr=#{container_ip} --cport=#{guest_port} 2>/dev/null"
+      "redir 127.0.0.1:#{host_port} #{container_ip}:#{guest_port} 2>/dev/null"
     )
   end
 
@@ -70,6 +71,15 @@ describe Vagrant::LXC::Action::ForwardPorts do
     expect(subject).not_to have_received(:spawn)
   end
 
+  it 'uses redir 2.x command line interface' do
+    subject.stub(system: true)
+    subject.stub(redir_version: 2)
+    subject.call(env)
+    expect(subject).to have_received(:spawn).with(
+      "redir --laddr=#{host_ip} --lport=#{host_port} --caddr=#{container_ip} --cport=#{guest_port} 2>/dev/null"
+    )
+  end
+
   it 'raises RedirNotInstalled error if `redir` is not installed' do
     subject.stub(system: false)
     expect { subject.call(env) }.to raise_error(Vagrant::LXC::Errors::RedirNotInstalled)
@@ -82,7 +92,7 @@ describe Vagrant::LXC::Action::ForwardPorts do
       subject.stub(system: true)
       subject.call(env)
       expect(subject).to have_received(:spawn).with(
-        "sudo redir --laddr=#{host_ip} --lport=#{host_port} --caddr=#{container_ip} --cport=#{guest_port} 2>/dev/null"
+        "sudo redir #{host_ip}:#{host_port} #{container_ip}:#{guest_port} 2>/dev/null"
       )
     end
 
@@ -91,7 +101,7 @@ describe Vagrant::LXC::Action::ForwardPorts do
       subject.stub(system: true)
       subject.call(env)
       expect(subject).to have_received(:spawn).with(
-        "sudo redir --laddr=127.0.0.1 --lport=#{host_port} --caddr=#{container_ip} --cport=#{guest_port} 2>/dev/null"
+        "sudo redir 127.0.0.1:#{host_port} #{container_ip}:#{guest_port} 2>/dev/null"
       )
     end
 
@@ -100,7 +110,7 @@ describe Vagrant::LXC::Action::ForwardPorts do
       subject.stub(system: true)
       subject.call(env)
       expect(subject).to have_received(:spawn).with(
-        "sudo redir --laddr=127.0.0.1 --lport=#{host_port} --caddr=#{container_ip} --cport=#{guest_port} 2>/dev/null"
+        "sudo redir 127.0.0.1:#{host_port} #{container_ip}:#{guest_port} 2>/dev/null"
       )
     end
   end


### PR DESCRIPTION
Since redir 2.x upstream is not evolving it, Joachim Nilsson adopted it
and have started to work on it and publish a new command line interface
(check out https://github.com/troglobit/redir). The redir 3.1 is already
available in Debian and Ubuntu in their stable releases.